### PR TITLE
Issue #76 - Column values with zero (0) are being replaced with ""

### DIFF
--- a/dist/parser/csv.js
+++ b/dist/parser/csv.js
@@ -102,7 +102,7 @@ var Parser = function () {
         var rows = [];
         var fillAndPush = function fillAndPush(row) {
           return rows.push(row.map(function (col) {
-            return col || '';
+            return col != null ? col : '';
           }));
         };
         // initialize the array with empty strings to handle 'unpopular' headers

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -86,7 +86,7 @@ class Parser {
     //Generate the csv output
     fillRows = function(result) {
       const rows = [];
-      const fillAndPush = (row) => rows.push(row.map(col => col || ''));
+      const fillAndPush = (row) => rows.push(row.map(col => col != null ? col : ''));
       // initialize the array with empty strings to handle 'unpopular' headers
       const newRow = () => new Array(self._headers.length).fill(null);
       const emptyRowIndexByHeader = {};

--- a/tests/array.js
+++ b/tests/array.js
@@ -2,26 +2,24 @@
 /* jshint esversion: 6 */
 /* jshint -W030 */
 
-var chai = require('chai');
-var expect = chai.expect;
-var jsonexport = require('../lib/index');
-var os = require('os');
+const {assert} = require('chai');
+const jsonexport = require('../lib/index');
+const os = require('os');
 
 describe('Array', () => {
-  it('simple', () => {
-    jsonexport([{
+  it('simple', async () => {
+    const csv = await jsonexport([{
       name: 'Bob',
       lastname: 'Smith'
     }, {
       name: 'James',
       lastname: 'David',
       escaped: 'I am a "quoted" field'
-    }], {}, (err, csv) => {
-      expect(csv).to.equal(`name,lastname,escaped${os.EOL}Bob,Smith${os.EOL}James,David,"I am a ""quoted"" field"`);
-    });
+    }], {})
+    assert.equal(csv, `name,lastname,escaped${os.EOL}Bob,Smith${os.EOL}James,David,"I am a ""quoted"" field"`);
   });
-  it('complex', () => {
-    jsonexport([{
+  it('complex', async () => {
+    const csv = await jsonexport([{
       id: 1,
       name: 'Bob',
       lastname: 'Smith',
@@ -37,12 +35,12 @@ describe('Array', () => {
         name: 'Julie',
         type: 'Mother'
       }
-    }], {}, (err, csv) => {
-      expect(csv).to.equal(`id,name,lastname,family.name,family.type${os.EOL}1,Bob,Smith,Peter,Father${os.EOL}2,James,David,Julie,Mother`);
-    });
+    }], {})
+
+    assert.equal(csv, `id,name,lastname,family.name,family.type${os.EOL}1,Bob,Smith,Peter,Father${os.EOL}2,James,David,Julie,Mother`);
   });
-  it('with nested arrays', () => {
-    jsonexport([{
+  it('with nested arrays', async () => {
+    const csv = await jsonexport([{
       a: {
         b: true,
         c: [{
@@ -66,12 +64,12 @@ describe('Array', () => {
           }
         ]
       }
-    }], {}, (err, csv) => {
-      expect(csv).to.equal(`a.b,a.c.d,a.e.f${os.EOL}true,1,${os.EOL},2,${os.EOL},3,${os.EOL},4,1${os.EOL},,2`);
-    });
+    }], {})
+
+    assert.equal(csv, `a.b,a.c.d,a.e.f${os.EOL}true,1,${os.EOL},2,${os.EOL},3,${os.EOL},4,1${os.EOL},,2`)
   });
-  it('with nested arrays & empty strings', () => {
-    jsonexport([
+  it('with nested arrays, empty strings, zero, undefined, & null', async () => {
+    const csv = await jsonexport([
       {
         "a": "",
         "b": "b",
@@ -91,11 +89,19 @@ describe('Array', () => {
           {
             "a": "a4",
             "b": "b4"
-          }
+          },
+          {
+            "a": 0,
+            "b": undefined
+          },
+          {
+            "a": 1,
+            "b": null
+          },
         ]
       }
-    ], {}, (err, csv) => {
-      expect(csv).to.equal(`a,b,c.a,c.b${os.EOL},b,a1,b1${os.EOL},,a2,b2${os.EOL},,,b3${os.EOL},,a4,b4`);
-    });
+    ], {})
+
+    assert.equal(csv, `a,b,c.a,c.b${os.EOL},b,a1,b1${os.EOL},,a2,b2${os.EOL},,,b3${os.EOL},,a4,b4${os.EOL},,0,${os.EOL},,1,`)
   });
 });

--- a/tests/array.js
+++ b/tests/array.js
@@ -68,7 +68,7 @@ describe('Array', () => {
 
     assert.equal(csv, `a.b,a.c.d,a.e.f${os.EOL}true,1,${os.EOL},2,${os.EOL},3,${os.EOL},4,1${os.EOL},,2`)
   });
-  it('with nested arrays, empty strings, zero, undefined, & null', async () => {
+  it('with nested arrays & empty strings', async () => {
     const csv = await jsonexport([
       {
         "a": "",
@@ -89,19 +89,11 @@ describe('Array', () => {
           {
             "a": "a4",
             "b": "b4"
-          },
-          {
-            "a": 0,
-            "b": undefined
-          },
-          {
-            "a": 1,
-            "b": null
-          },
+          }
         ]
       }
     ], {})
 
-    assert.equal(csv, `a,b,c.a,c.b${os.EOL},b,a1,b1${os.EOL},,a2,b2${os.EOL},,,b3${os.EOL},,a4,b4${os.EOL},,0,${os.EOL},,1,`)
+    assert.equal(csv, `a,b,c.a,c.b${os.EOL},b,a1,b1${os.EOL},,a2,b2${os.EOL},,,b3${os.EOL},,a4,b4`)
   });
 });

--- a/tests/object.js
+++ b/tests/object.js
@@ -3,7 +3,7 @@
 /* jshint -W030 */
 
 var chai = require('chai');
-var expect = chai.expect;
+var {assert, expect} = require('chai');
 var jsonexport = require('../lib/index');
 var os = require('os');
 
@@ -14,17 +14,16 @@ if( isRemoteTest ){
 }
 
 describe('Object', () => {
-  it('simple', () => {
-    jsonexport({
+  it('simple', async () => {
+    const csv = await jsonexport({
       lang: 'Node.js',
       module: 'jsonexport'
-    }, {}, (err, csv) => {
-      expect(csv).to.equal(`lang,Node.js${os.EOL}module,jsonexport`);
-    });
+    }, {})
+    assert.equal(csv, `lang,Node.js${os.EOL}module,jsonexport`);
   });
 
-  it('complex', () => {
-    jsonexport({
+  it('complex', async () => {
+    const csv = await jsonexport({
       cars: 12,
       roads: 5,
       traffic: 'slow',
@@ -35,12 +34,11 @@ describe('Object', () => {
       },
       size: [10, 20],
       escaped: 'I am a "quoted" field'
-    }, {}, (err, csv) => {
-      expect(csv).to.equal(`cars,12${os.EOL}roads,5${os.EOL}traffic,slow${os.EOL}speed.max,123${os.EOL}speed.avg,20${os.EOL}speed.min,5${os.EOL}size,10;20${os.EOL}escaped,"I am a ""quoted"" field"`);
-    });
+    }, {})
+    assert.equal(csv, `cars,12${os.EOL}roads,5${os.EOL}traffic,slow${os.EOL}speed.max,123${os.EOL}speed.avg,20${os.EOL}speed.min,5${os.EOL}size,10;20${os.EOL}escaped,"I am a ""quoted"" field"`);
   });
 
-  it('Github #41 p1',()=>{
+  it('Github #41 p1',async ()=>{
     var contacts = [{
         name: 'Bob',
         lastname: 'Smith',
@@ -53,24 +51,22 @@ describe('Object', () => {
         test: true
     }];
 
-    jsonexport(contacts, (err, csv)=>{
-      expect(csv).to.equal(`name,lastname,status,test${os.EOL}Bob,Smith,,true${os.EOL}James,David,fired,true`);
-    });
+    const csv = await jsonexport(contacts)
+    assert.equal(csv, `name,lastname,status,test${os.EOL}Bob,Smith,,true${os.EOL}James,David,fired,true`);
   });
 
-  it('Github #41 p2',()=>{
+  it('Github #41 p2',async ()=>{
     var contacts = {
       'a' : 'another field',
       'b' : '',
       'c' : 'other field'
     };
 
-    jsonexport(contacts, (err, csv)=>{
-      expect(csv).to.equal(`a,another field${os.EOL}b,${os.EOL}c,other field`);
-    });
+    const csv = await jsonexport(contacts)
+    assert.equal(csv, `a,another field${os.EOL}b,${os.EOL}c,other field`);
   });
 
-  it('Buffer to String - Github #48',()=>{
+  it('Buffer to String - Github #48',async ()=>{
     var contacts = {
       '0' : true,
       '1' : [11,22,33],
@@ -110,8 +106,21 @@ describe('Object', () => {
       }
     };
 
-    jsonexport(contacts, options, (err, csv)=>{
-      expect(csv).to.equal(`0,replaced-boolean${os.EOL}1,replaced-array${os.EOL}2,bad ace${os.EOL}a,parentless-a${os.EOL}b,replaced-string${os.EOL}c,replaced-number${os.EOL}d.x,other field`);
-    });
+    const csv = await jsonexport(contacts, options)
+    assert.equal(csv, `0,replaced-boolean${os.EOL}1,replaced-array${os.EOL}2,bad ace${os.EOL}a,parentless-a${os.EOL}b,replaced-string${os.EOL}c,replaced-number${os.EOL}d.x,other field`);
+  });
+
+  it('Zero, undefined, & null', async () => {
+    const csv = await jsonexport([
+      {
+        "a": 0,
+        "b": undefined,
+        "c": null,
+        "d": 1,
+        "e": "this"
+      }
+    ], {})
+
+    assert.equal(csv, `a,b,c,d,e\n0,,,1,this`)
   });
 });


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
This fix is described by https://github.com/kaue/jsonexport/issues/76

## Steps to Test or Reproduce
Noticed that on upgrading from 2.4.1 to 2.5.2 (and also 3.0.0) that the library has started to convert columns with integer values of 0 into "". To reproduce use `jsonexport` against data with a 0 value.


## Impacted Areas in Application
List general components of the application that this PR will affect:

* `jsonexport` will support columns holding 0
