### PR TITLE
Bugfix/complex json array unexpected behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Change log
 ----------------------
+- v3.0.2 - fix fillGaps issue for first record #78 (sregger)
 - v3.0.1 - fix column values with zero (0) are being replaced with "" (sregger)
 - v3.0.0 - Promise API & fillTopRow
 - v2.5.2 - fix stream memory limit (issue #64)

--- a/README.md
+++ b/README.md
@@ -257,6 +257,127 @@ speed.min,5
 size,10;20
 ```
 
+### Complex JSON Array
+
+#### Code (fillGaps, fillTopRow = true)
+
+```javascript
+const jsonexport = require('jsonexport');
+
+const stats = [{
+                  manufacturer: 'BMW',
+                  country: 'USA',
+                  inventory: {
+                    profile: ['public'],
+                    cars: [
+                      {
+                        model: '3-series',
+                        price: '34850'
+                      },
+                      {
+                        model: '5-series',
+                        price: '55000'
+                      },
+                      {
+                        model: '7-series',
+                        price: '72000'
+                      }
+                    ]
+                  },
+                  category: [
+                    {
+                      sedan: [
+                        {
+                          seats: 4,
+                          doors: 4,
+                          sunroof: true
+                        }
+                      ]
+                    }
+                  ],
+                  location: {
+                    address: [
+                      {
+                        city: 'Raleigh',
+                        state: 'NC',
+                        dealer: 'Raleigh Motors'
+                      },
+                      {
+                        city: 'Durham',
+                        state: 'NC',
+                        dealer: 'Durham BMW'
+                      }
+                    ]
+                  }
+                },
+                {
+                  manufacturer: 'Audi',
+                  country: 'USA',
+                  inventory: {
+                    profile: ['public'],
+                    cars: [
+                      {
+                        model: 'Q3',
+                        price: '36700'
+                      },
+                      {
+                        model: 'Q5',
+                        price: '48900'
+                      },
+                      {
+                        model: 'Q7',
+                        price: '91350'
+                      }
+                    ]
+                  },
+                  category: [
+                    {
+                      sedan: [
+                        {
+                          seats: 7,
+                          doors: 4,
+                          sunroof: true,
+                          heatedSeats: 'front'
+                        }
+                      ]
+                    }
+                  ],
+                  location: {
+                    address: [
+                      {
+                        city: 'Greensboro',
+                        state: 'NC',
+                        dealer: 'Audi Greensboro'
+                      },
+                      {
+                        city: 'Asheville',
+                        state: 'NC',
+                        dealer: 'Asheville Audi Motors'
+                      }
+                    ]
+                  }
+                }
+              ];
+
+jsonexport(stats, {fillGaps: true, fillTopRow: true}, 
+    function(err, csv){
+    if(err) return console.error(err);
+    console.log(csv);
+});
+```
+
+#### Result
+
+```
+manufacturer,country,inventory.profile,inventory.cars.model,inventory.cars.price,category.sedan.seats,category.sedan.doors,category.sedan.sunroof,location.address.city,location.address.state,location.address.dealer,category.sedan.heatedSeats
+BMW,USA,public,3-series,34850,4,4,true,Raleigh,NC,Raleigh Motors
+BMW,USA,public,5-series,55000,4,4,true,Durham,NC,Durham BMW
+BMW,USA,public,7-series,72000,4,4,true,Durham,NC,Durham BMW
+Audi,USA,public,Q3,36700,7,4,true,Greensboro,NC,Audi Greensboro,front
+Audi,USA,public,Q5,48900,7,4,true,Asheville,NC,Asheville Audi Motors,front
+Audi,USA,public,Q7,91350,7,4,true,Asheville,NC,Asheville Audi Motors,front
+```
+
 ## Options
 
 In order to get the most of out of this module, you can customize many parameters and functions.

--- a/dist/parser/csv.js
+++ b/dist/parser/csv.js
@@ -127,9 +127,17 @@ var Parser = function () {
             emptyRowIndexByHeader[elementHeaderIndex] = emptyRowIndexByHeader[elementHeaderIndex] || 0;
             // make sure there isnt a empty row for this header
             if (self._options.fillTopRow && emptyRowIndexByHeader[elementHeaderIndex] < rows.length) {
+              // Fill gap between row's current length and elementHeaderIndex with ""
+              var rowGap = elementHeaderIndex - rows[emptyRowIndexByHeader[elementHeaderIndex]].length;
+              if (rowGap > 0) {
+                rows[emptyRowIndexByHeader[elementHeaderIndex]] = rows[emptyRowIndexByHeader[elementHeaderIndex]].concat(Array(rowGap).fill(""));
+              }
               rows[emptyRowIndexByHeader[elementHeaderIndex]][elementHeaderIndex] = self._escape(element.value);
               emptyRowIndexByHeader[elementHeaderIndex] += 1;
               continue;
+            }
+            if (currentRow.length < elementHeaderIndex) {
+              currentRow = currentRow.concat(Array(elementHeaderIndex - currentRow.length).fill(""));
             }
             currentRow[elementHeaderIndex] = self._escape(element.value);
             emptyRowIndexByHeader[elementHeaderIndex] += 1;

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -100,9 +100,19 @@ class Parser {
         emptyRowIndexByHeader[elementHeaderIndex] = emptyRowIndexByHeader[elementHeaderIndex] || 0;
         // make sure there isnt a empty row for this header
         if (self._options.fillTopRow && emptyRowIndexByHeader[elementHeaderIndex] < rows.length) {
+          // Fill gap between row's current length and elementHeaderIndex with ""
+          let rowGap = elementHeaderIndex - rows[emptyRowIndexByHeader[elementHeaderIndex]].length;
+          if (rowGap > 0) {
+            rows[emptyRowIndexByHeader[elementHeaderIndex]] = rows[emptyRowIndexByHeader[elementHeaderIndex]].concat(
+                Array(rowGap).fill(""));
+          }
           rows[emptyRowIndexByHeader[elementHeaderIndex]][elementHeaderIndex] = self._escape(element.value);
           emptyRowIndexByHeader[elementHeaderIndex] += 1;
           continue;
+        }
+        if (currentRow.length < elementHeaderIndex) {
+          currentRow = currentRow.concat(
+              Array(elementHeaderIndex - currentRow.length).fill(""));
         }
         currentRow[elementHeaderIndex] = self._escape(element.value);
         emptyRowIndexByHeader[elementHeaderIndex] += 1;

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -40,7 +40,7 @@ class Parser {
 
     if (this._options.rename && this._options.rename.length > 0)
       headers = headers.map((header) => this._options.rename[this._options.headers.indexOf(header)] || header);
-      
+
     if (this._options.forceTextDelimiter) {
       headers = headers.map((header) => {
         return `${this._options.textDelimiter}${header}${this._options.textDelimiter}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonexport",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Makes easy to convert JSON to CSV",
   "main": "./lib",
   "scripts": {

--- a/tests/object.js
+++ b/tests/object.js
@@ -7,7 +7,6 @@ var {assert, expect} = require('chai');
 var jsonexport = require('../lib/index');
 var os = require('os');
 
-
 const isRemoteTest = process.env.APPVEYOR || process.env.TRAVIS;
 if( isRemoteTest ){
   console.log('\x1b[34mRemote testing server detected on '+os.type()+' '+os.platform()+' '+os.release()+'\x1b[0m');
@@ -100,7 +99,7 @@ describe('Object', () => {
           if(parent===contacts){
             return 'parentless-'+index;
           }
-          
+
           return value.toString();
         }
       }
@@ -121,6 +120,6 @@ describe('Object', () => {
       }
     ], {})
 
-    assert.equal(csv, `a,b,c,d,e\n0,,,1,this`)
+    assert.equal(csv, `a,b,c,d,e`+ os.EOL +`0,,,1,this`)
   });
 });


### PR DESCRIPTION
## Status
Ready. Fixes #78 

## Description
The first record rows were not properly filled because the rows that were being constructed were sparse. Hence, fillGaps was not able to find the indexes and ignored to fill. My change fills the rows from length of row to current index with empty strings.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ x] Documentation


## Steps to Test or Reproduce
See issue #78 to reproduce the bug in 3.0.1

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 
