### PR TITLE
Support duplicate headers and columns in CSV

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,8 @@ module.exports = function() {
     fillGaps: false, //          Boolean
     verticalOutput: true, //     Boolean
     forceTextDelimiter: false, //Boolean
+    mapHeaders: null, //         Function
+    typeHandlers: {}, //         Object
   };
   // argument parsing
   let json, userOptions, callback;

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -83,6 +83,19 @@ class Parser {
       return index;
     };
 
+    let getAllIndexes = (header) => {
+      var indexes = [], i;
+      for(i = 0; i < self._headers.length; i++)
+          if (self._headers[i] === header)
+              indexes.push(i);
+      
+      if (indexes.length === 0) {
+        self._headers.push(header);
+        indexes.push(self._headers.length -1);
+      }
+      return indexes;
+  }
+
     //Generate the csv output
     fillRows = function(result) {
       const rows = [];
@@ -92,20 +105,25 @@ class Parser {
       const emptyRowIndexByHeader = {};
       let currentRow = newRow();
       for (let element of result) {
-        let elementHeaderIndex = getHeaderIndex(element.item);
-        if (currentRow[elementHeaderIndex] != undefined) {
-          fillAndPush(currentRow);
-          currentRow = newRow();
-        }
-        emptyRowIndexByHeader[elementHeaderIndex] = emptyRowIndexByHeader[elementHeaderIndex] || 0;
-        // make sure there isn't a empty row for this header
-        if (self._options.fillTopRow && emptyRowIndexByHeader[elementHeaderIndex] < rows.length) {
-          rows[emptyRowIndexByHeader[elementHeaderIndex]][elementHeaderIndex] = self._escape(element.value);
+        // headerIndexes is usually a single element array, 
+        // except for cases where we have the same header/column repeated multiple times in tables
+        const headerIndexes = getAllIndexes(element.item);
+        
+        for(let elementHeaderIndex of headerIndexes) {
+          if (currentRow[elementHeaderIndex] != undefined) {
+            fillAndPush(currentRow);
+            currentRow = newRow();
+          }
+          emptyRowIndexByHeader[elementHeaderIndex] = emptyRowIndexByHeader[elementHeaderIndex] || 0;
+          // make sure there isn't a empty row for this header
+          if (self._options.fillTopRow && emptyRowIndexByHeader[elementHeaderIndex] < rows.length) {
+            rows[emptyRowIndexByHeader[elementHeaderIndex]][elementHeaderIndex] = self._escape(element.value);
+            emptyRowIndexByHeader[elementHeaderIndex] += 1;
+            continue;
+          }
+          currentRow[elementHeaderIndex] = self._escape(element.value);
           emptyRowIndexByHeader[elementHeaderIndex] += 1;
-          continue;
         }
-        currentRow[elementHeaderIndex] = self._escape(element.value);
-        emptyRowIndexByHeader[elementHeaderIndex] += 1;
       }
       // push last row
       if (currentRow.length > 0) {

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -39,7 +39,7 @@ class Parser {
     let headers = this._headers;
 
     if (this._options.rename && this._options.rename.length > 0)
-      headers = headers.map((header) => this._options.rename[this._options.headers.indexOf(header)] || header);
+      headers = headers.map((header, idx) => this._options.rename[idx] || this._options.rename[this._options.headers.indexOf(header)] || header);
       
     if (this._options.forceTextDelimiter) {
       headers = headers.map((header) => {


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
This PR adds support for duplicate headers and rendering of the data for those duplicate headers. For use cases, where the same data needs to be represented more than once in table/csv, but with same or different header display names.

## Todos
- [ ] Tests
- [ ] Documentation


## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```
