### PR TITLE
add forceTextStrings option to give csv readers a hint to text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ In order to get the most of out of this module, you can customize many parameter
     - Use `;` for (**windows excel .csv format**).
 - `textDelimiter` - `String` The character used to escape the text content if needed (default to `"`)
 - `forceTextDelimiter` - `Boolean` Set this option to true to wrap every data item and header in the textDelimiter. Defaults to `false`
+- `forceTextStrings` - `Boolean` Set this option to true to wrap every string data item and header in the textDelimiter. Defaults to `false`
 - `endOfLine` - `String` Replace the OS default EOL.
 - `mainPathItem` - `String` Every header will have the `mainPathItem` as the base.
 - `arrayPathString` - `String` This is used to output primitive arrays in a single column, defaults to `;`

--- a/dist/core/escape-delimiters.js
+++ b/dist/core/escape-delimiters.js
@@ -9,7 +9,7 @@
    For example: "aaa","b""bb","ccc"
 */
 
-module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter) {
+module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter, forceTextStrings) {
   var endOfLine = '\n';
 
   if (typeof textDelimiter !== 'string') {
@@ -30,14 +30,17 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTe
   };
 
   return function (value) {
-    if (forceTextDelimiter) value = "" + value;
+    var force = forceTextDelimiter;
+    if (forceTextStrings && typeof value === 'string') force = true;
+
+    if (force) value = "" + value;
 
     if (!value.replace) return value;
     // Escape the textDelimiters contained in the field
     value = value.replace(textDelimiterRegex, escapedDelimiter);
 
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (forceTextDelimiter || enclosingCondition(value)) {
+    if (force || enclosingCondition(value)) {
       value = textDelimiter + value + textDelimiter;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,7 +37,8 @@ module.exports = function () {
     includeHeaders: true, //     Boolean
     fillGaps: false, //          Boolean
     verticalOutput: true, //     Boolean
-    forceTextDelimiter: false //Boolean
+    forceTextDelimiter: false, //Boolean
+    forceTextStrings: false //  Boolean
   };
   // argument parsing
   var json = void 0,

--- a/dist/parser/csv.js
+++ b/dist/parser/csv.js
@@ -20,7 +20,7 @@ var Parser = function () {
     this._options = options || {};
     this._handler = new Handler(this._options);
     this._headers = this._options.headers || [];
-    this._escape = require('../core/escape-delimiters')(this._options.textDelimiter, this._options.rowDelimiter, this._options.forceTextDelimiter);
+    this._escape = require('../core/escape-delimiters')(this._options.textDelimiter, this._options.rowDelimiter, this._options.forceTextDelimiter, this._options.forceTextStrings);
   }
 
   /**
@@ -237,7 +237,7 @@ var Parser = function () {
         return _this._options.rename[_this._options.headers.indexOf(header)] || header;
       });
 
-      if (this._options.forceTextDelimiter) {
+      if (this._options.forceTextDelimiter || this._options.forceTextStrings) {
         headers = headers.map(function (header) {
           return '' + _this._options.textDelimiter + header + _this._options.textDelimiter;
         });

--- a/lib/core/escape-delimiters.js
+++ b/lib/core/escape-delimiters.js
@@ -9,7 +9,7 @@
    For example: "aaa","b""bb","ccc"
 */
 
-module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter) {  
+module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTextDelimiter, forceTextStrings) {  
   let endOfLine = '\n';
 
   if (typeof textDelimiter !== 'string') {
@@ -31,14 +31,17 @@ module.exports = function escapedDelimiters(textDelimiter, rowDelimiter, forceTe
         value.indexOf(endOfLine) >= 0);
 
   return function(value) {
-    if(forceTextDelimiter) value = "" + value;
+    let force=forceTextDelimiter;
+    if(forceTextStrings && typeof(value)==='string') force=true;
+    
+    if(force) value = "" + value;
 
     if (!value.replace) return value;
     // Escape the textDelimiters contained in the field
     value = value.replace(textDelimiterRegex, escapedDelimiter);
     
     // Escape the whole field if it contains a rowDelimiter or a linebreak or double quote
-    if (forceTextDelimiter || enclosingCondition(value)) {
+    if (force || enclosingCondition(value)) {
       value = textDelimiter + value + textDelimiter;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ module.exports = function() {
     fillGaps: false, //          Boolean
     verticalOutput: true, //     Boolean
     forceTextDelimiter: false, //Boolean
+    forceTextStrings: false, //  Boolean
   };
   // argument parsing
   let json, userOptions, callback;

--- a/lib/parser/csv.js
+++ b/lib/parser/csv.js
@@ -16,7 +16,8 @@ class Parser {
     this._escape = require('../core/escape-delimiters')(
       this._options.textDelimiter,
       this._options.rowDelimiter,
-      this._options.forceTextDelimiter
+      this._options.forceTextDelimiter,
+      this._options.forceTextStrings
     );
   }
 
@@ -41,7 +42,7 @@ class Parser {
     if (this._options.rename && this._options.rename.length > 0)
       headers = headers.map((header) => this._options.rename[this._options.headers.indexOf(header)] || header);
       
-    if (this._options.forceTextDelimiter) {
+    if (this._options.forceTextDelimiter || this._options.forceTextStrings) {
       headers = headers.map((header) => {
         return `${this._options.textDelimiter}${header}${this._options.textDelimiter}`;
       });

--- a/tests/escape-delimiters.js
+++ b/tests/escape-delimiters.js
@@ -14,7 +14,8 @@ describe('escapeDelimiters', () => {
     simpleRow: 'I am a \n multi line field',
     complexField: 'I am a \n multi line field containing "textDelimiters"',
     alreadyEscaped: '"I contain "double quotes" everywhere !"',
-    forceEscape: 42
+    forceEscape: 42,
+    forceString: "Sample",
   };
 
   it('should escape textDelimiters', () => {
@@ -38,9 +39,22 @@ describe('escapeDelimiters', () => {
   });
 
   it('should escape if forceTextDelimiter flag is true', () => {
-    var escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', true);
+    const escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', true);
 
     expect(escapeDelimiters(mocks.forceEscape)).to.be.a.string;
     expect(escapeDelimiters(mocks.forceEscape)).to.be.equal('"42"');
+  });
+
+  it('should escape if forceTextStrings flag is true', () => {
+    const escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', false, true);
+
+    expect(escapeDelimiters(mocks.forceString)).to.be.a.string;
+    expect(escapeDelimiters(mocks.forceString)).to.be.equal('"Sample"');
+  });
+  it('should not escape if forceTextStrings flag is true', () => {
+    const escapeDelimiters = require('../lib/core/escape-delimiters')('"', '\n', false, true);
+
+    expect(escapeDelimiters(mocks.forceEscape)).to.be.a('number');
+    expect(escapeDelimiters(mocks.forceEscape)).to.be.equal(42);
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
Quotes string fields so that when importing the csv, it can automatically detect text columns vs numeric columns.
This helps a lot with having working sort column on version numbers where 3.1 and 3.11 are not numbers but strings

* 
